### PR TITLE
press releaseのlistとkeywordのlistを作成しました

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
     <main class="main__container">
       <div class="main__content">
         <h2 class="main__content__title">新着プレスリリース</h2>
-        <div class="prlist">
+        <div class="latest-pr-list">
           <!-- start  press release cards  -->
           <div class="card--prlist">
             <div>

--- a/index.html
+++ b/index.html
@@ -114,27 +114,115 @@
         <h2 class="main__content__title">新着プレスリリース</h2>
         <div class="latest-pr-list">
           <!-- start  press release cards  -->
-          <div class="card--prlist">
+          <div class="card card--latest-pr">
             <div>
-            <h3 class="card__title--pr">BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進...</h3>
-            <div class="card__time">
+            <h3 class="card__title card__title--latest-pr">BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進...</h3>
+            <div class="card__time card__time--latest-pr">
               <img src="img/global/clock.png" alt="時計" class="time__icon"/>
               <p class="time__text">5分前</p>
               <p class="card__company-name">BRITA Japan株式会社</p>
             </div>
             </div>
-            <img src="img/main/thumbnail.png" alt="BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進..." class="card__img--pr"/>
+            <img src="img/main/thumbnail.png" alt="BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進..." class="card__img--latest-pr"/>
           </div>
-          <div class="card--prlist">
+         <div class="card card--latest-pr">
             <div>
-            <h3 class="card__title--pr">BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進...</h3>
-            <div class="card__time">
+            <h3 class="card__title card__title--latest-pr">BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進...</h3>
+            <div class="card__time card__time--latest-pr">
               <img src="img/global/clock.png" alt="時計" class="time__icon"/>
               <p class="time__text">5分前</p>
               <p class="card__company-name">BRITA Japan株式会社</p>
             </div>
             </div>
-            <img src="img/main/thumbnail.png" alt="BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進..." class="card__img--pr"/>
+            <img src="img/main/thumbnail.png" alt="BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進..." class="card__img--latest-pr"/>
+          </div>
+         <div class="card card--latest-pr">
+            <div>
+            <h3 class="card__title card__title--latest-pr">BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進...</h3>
+            <div class="card__time card__time--latest-pr">
+              <img src="img/global/clock.png" alt="時計" class="time__icon"/>
+              <p class="time__text">5分前</p>
+              <p class="card__company-name">BRITA Japan株式会社</p>
+            </div>
+            </div>
+            <img src="img/main/thumbnail.png" alt="BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進..." class="card__img--latest-pr"/>
+          </div>
+          <div class="card card--latest-pr">
+            <div>
+            <h3 class="card__title card__title--latest-pr">BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進...</h3>
+            <div class="card__time card__time--latest-pr">
+              <img src="img/global/clock.png" alt="時計" class="time__icon"/>
+              <p class="time__text">5分前</p>
+              <p class="card__company-name">BRITA Japan株式会社</p>
+            </div>
+            </div>
+            <img src="img/main/thumbnail.png" alt="BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進..." class="card__img--latest-pr"/>
+          </div>
+           <div class="card card--latest-pr">
+            <div>
+            <h3 class="card__title card__title--latest-pr">BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進...</h3>
+            <div class="card__time card__time--latest-pr">
+              <img src="img/global/clock.png" alt="時計" class="time__icon"/>
+              <p class="time__text">5分前</p>
+              <p class="card__company-name">BRITA Japan株式会社</p>
+            </div>
+            </div>
+            <img src="img/main/thumbnail.png" alt="BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進..." class="card__img--latest-pr"/>
+          </div>
+            <div class="card card--latest-pr">
+            <div>
+            <h3 class="card__title card__title--latest-pr">BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進...</h3>
+            <div class="card__time card__time--latest-pr">
+              <img src="img/global/clock.png" alt="時計" class="time__icon"/>
+              <p class="time__text">5分前</p>
+              <p class="card__company-name">BRITA Japan株式会社</p>
+            </div>
+            </div>
+            <img src="img/main/thumbnail.png" alt="BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進..." class="card__img--latest-pr"/>
+          </div>
+          <div class="card card--latest-pr">
+            <div>
+            <h3 class="card__title card__title--latest-pr">BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進...</h3>
+            <div class="card__time card__time--latest-pr">
+              <img src="img/global/clock.png" alt="時計" class="time__icon"/>
+              <p class="time__text">5分前</p>
+              <p class="card__company-name">BRITA Japan株式会社</p>
+            </div>
+            </div>
+            <img src="img/main/thumbnail.png" alt="BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進..." class="card__img--latest-pr"/>
+          </div>
+           <div class="card card--latest-pr">
+            <div>
+            <h3 class="card__title card__title--latest-pr">BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進...</h3>
+            <div class="card__time card__time--latest-pr">
+              <img src="img/global/clock.png" alt="時計" class="time__icon"/>
+              <p class="time__text">5分前</p>
+              <p class="card__company-name">BRITA Japan株式会社</p>
+            </div>
+            </div>
+            <img src="img/main/thumbnail.png" alt="BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進..." class="card__img--latest-pr"/>
+          </div>
+          <div class="card card--latest-pr">
+            <div>
+            <h3 class="card__title card__title--latest-pr">BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進...</h3>
+            <div class="card__time card__time--latest-pr">
+              <img src="img/global/clock.png" alt="時計" class="time__icon"/>
+              <p class="time__text">5分前</p>
+              <p class="card__company-name">BRITA Japan株式会社</p>
+            </div>
+            </div>
+            <img src="img/main/thumbnail.png" alt="BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進..." class="card__img--latest-pr"/>
+          </div>
+         <div class="card card--latest-pr">
+            <div>
+            <h3 class="card__title card__title--latest-pr">BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進...</h3>
+            <div class="card__time card__time--latest-pr">
+              <img src="img/global/clock.png" alt="時計" class="time__icon"/>
+              <p class="time__text">5分前</p>
+              <p class="card__company-name">BRITA Japan株式会社</p>
+            </div>
+            </div>
+            <img src="img/main/thumbnail.png" alt="BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進..." class="card__img--latest-pr"/>
           </div>
 
           <!-- end press release cards  -->

--- a/index.html
+++ b/index.html
@@ -115,14 +115,28 @@
         <div class="prlist">
           <!-- start  press release cards  -->
           <div class="card--prlist">
-            <h3>BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進...</h3>
-            <img src="img/main/thumbnail.png" alt="BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進..." class="card__img"/>
+            <div>
+            <h3 class="card__title--pr">BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進...</h3>
             <div class="card__time">
               <img src="img/global/clock.png" alt="時計" class="time__icon"/>
-              <p class="time__text">2019年06月27日 11:00</p>
-              <p>BRITA Japan株式会社</p>
+              <p class="time__text">5分前</p>
+              <p class="card__company-name">BRITA Japan株式会社</p>
             </div>
+            </div>
+            <img src="img/main/thumbnail.png" alt="BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進..." class="card__img--pr"/>
           </div>
+          <div class="card--prlist">
+            <div>
+            <h3 class="card__title--pr">BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進...</h3>
+            <div class="card__time">
+              <img src="img/global/clock.png" alt="時計" class="time__icon"/>
+              <p class="time__text">5分前</p>
+              <p class="card__company-name">BRITA Japan株式会社</p>
+            </div>
+            </div>
+            <img src="img/main/thumbnail.png" alt="BRITA JapanがG20のユース向け公式付属会議「Y20 SUMMIT 2019 JAPAN」に登壇！マイボトル化推進..." class="card__img--pr"/>
+          </div>
+
           <!-- end press release cards  -->
         </div>
       </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,7 +1,6 @@
 .main__container {
   padding-inline: 176px;
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
 }
 
 .main__content {
@@ -12,10 +11,42 @@
   height: 30px;
   font-size: 24px;
   margin-top: 20px;
+  margin-bottom: 30px;
+  font-weight: 700;
+  color: var(--text-dark-gray);
 }
 
 .prlist {
   padding-top: 20px;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.card--prlist {
+  color: var(--text-semi-light-gray);
+  background-color: var(--bg-white);
+  display: flex;
+  justify-content: space-between;
+  width: 380px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--bg-gray);
+}
+
+.card__title--pr {
+  font-style: normal;
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 160%;
+  color: var(--text-dark-gray);
+  grid-column: 1 / 3;
+  margin-bottom: 20px
+}
+
+.card__img--pr {
+  grid-column: 4 / 4;
+  width: 100px;
+  height: 66px;
+  object-fit: cover;
 }
 
 .sidebar {
@@ -25,7 +56,10 @@
 .sidebar__title {
   height: 30px;
   font-size: 18px;
+  font-weight: 700;
+  color: var(--text-dark-gray);
   margin-top: 20px;
+  margin-bottom: 30px;
 }
 
 .keyword-list {

--- a/styles/main.css
+++ b/styles/main.css
@@ -12,7 +12,7 @@
   font-size: 24px;
   margin-top: 20px;
   margin-bottom: 30px;
-  font-weight: 700;
+  font-weight: bold;
   color: var(--text-dark-gray);
 }
 
@@ -34,7 +34,7 @@
 
 .card__title--pr {
   font-style: normal;
-  font-weight: 700;
+  font-weight: bold;
   font-size: 14px;
   line-height: 160%;
   color: var(--text-dark-gray);
@@ -56,7 +56,7 @@
 .sidebar__title {
   height: 30px;
   font-size: 18px;
-  font-weight: 700;
+  font-weight: bold;
   color: var(--text-dark-gray);
   margin-top: 20px;
   margin-bottom: 30px;

--- a/styles/main.css
+++ b/styles/main.css
@@ -16,7 +16,7 @@
   color: var(--text-dark-gray);
 }
 
-.prlist {
+.latest-pr-list {
   padding-top: 20px;
   display: grid;
   grid-template-columns: repeat(2, 1fr);

--- a/styles/main.css
+++ b/styles/main.css
@@ -22,7 +22,7 @@
   grid-template-columns: repeat(2, 1fr);
 }
 
-.card--prlist {
+.card--latest-pr{
   color: var(--text-semi-light-gray);
   background-color: var(--bg-white);
   display: flex;
@@ -30,23 +30,30 @@
   width: 380px;
   padding-bottom: 10px;
   border-bottom: 1px solid var(--bg-gray);
+  margin-bottom: 20px;
 }
 
-.card__title--pr {
+.card__title--latest-pr {
   font-style: normal;
   font-weight: bold;
   font-size: 14px;
   line-height: 160%;
   color: var(--text-dark-gray);
   grid-column: 1 / 3;
-  margin-bottom: 20px
+  margin-top: 0;
+  margin-bottom: 20px;
+  padding-inline: 0;
 }
 
-.card__img--pr {
+.card__img--latest-pr {
   grid-column: 4 / 4;
   width: 100px;
   height: 66px;
   object-fit: cover;
+}
+
+.card__time--latest-pr {
+  padding-inline: 0;
 }
 
 .sidebar {


### PR DESCRIPTION
## Issue
#6 

## done
- contentsとsideをCSSで分割する
- contents内のタイトルをCSSで実装
- sideのタイトルをCSSで実装
- contents内のカラムをCSSで実装する: contentsのborderがbottomのみあり
- contents内のカラムの内部のhtmlを実装
- contents内のカラムの内部のCSSを実装

## Picture
- Figma
<img width="1728" src="https://user-images.githubusercontent.com/84004458/237005882-9540b96d-dc63-4be2-8b4b-1d9fbcdb8dbd.png">

- Screenshot
<img width="1728" alt="スクリーンショット 2023-05-12 16 18 15" src="https://github.com/ShunDeveloper/prtimes_htmlcss/assets/84004458/3e338047-6e1b-4268-b01c-c4f138ce25c6">
